### PR TITLE
Default Action of IntanceLaunching webhook updated

### DIFF
--- a/template/amazon-eks-nodegroup-multus.yaml
+++ b/template/amazon-eks-nodegroup-multus.yaml
@@ -573,7 +573,7 @@ Resources:
     Properties:
       AutoScalingGroupName: !Ref NodeGroup
       LifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING"
-      DefaultResult: "ABANDON"
+      DefaultResult: "CONTINUE"
       HeartbeatTimeout: "300"
   LchookEc2Term:
     Type: "AWS::AutoScaling::LifecycleHook"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

++++ When the worked nodes are launched using this template, instances go in reboot cycle as the default action of EC2_Intance_Launching hook is 'ABANDON', Changed its value to 'CONTINUE'

